### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,29 +4,17 @@ on:
     pull_request:
         branches:
             - main
-    push:
-        branches:
-            - main
+
+concurrency:
+  group: ${{ github.workflow }} - ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    cancel-previous:
-        name: Cancel Previous Jobs
-        permissions:
-            contents: read
-            actions: write
-        runs-on: ubuntu-latest
-        steps:
-            - name: Cancel Previous Build
-              uses: styfle/cancel-workflow-action@0.12.1
-              with:
-                  access_token: ${{ github.token }}
-
     lint:
         name: Lint
         permissions:
             contents: read
         runs-on: ubuntu-latest
-        needs: cancel-previous
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,6 @@ concurrency:
 jobs:
     lint:
         name: Lint
-        permissions:
-            contents: read
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -31,36 +29,9 @@ jobs:
             - name: Lint
               run: make clean lint
 
-    build:
-        name: Build
-        permissions:
-            contents: read
-        runs-on: ubuntu-latest
-        needs: lint
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-            - name: Validate Gradle Wrapper
-              uses: gradle/wrapper-validation-action@v1
-            - name: Copy CI gradle.properties
-              run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
-            - name: Set up JDK
-              uses: actions/setup-java@v4
-              with:
-                  distribution: 'zulu'
-                  java-version: '17'
-                  cache: 'gradle'
-            - name: APK
-              run: make clean assemble
-            - name: Bundle
-              run: make clean bundle
-
     test:
         name: Test (unit)
-        permissions:
-            contents: read
         runs-on: ubuntu-latest
-        needs: build
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -79,11 +50,8 @@ jobs:
 
     androidTest:
         name: Test (instrumented)
-        permissions:
-            contents: read
         runs-on: macos-latest
         timeout-minutes: 45
-        needs: test
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -98,3 +66,24 @@ jobs:
                   java-version: '17'
                   cache: 'gradle'
 
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        needs: [lint, test, androidTest]
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Validate Gradle Wrapper
+              uses: gradle/wrapper-validation-action@v1
+            - name: Copy CI gradle.properties
+              run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+            - name: Set up JDK
+              uses: actions/setup-java@v4
+              with:
+                  distribution: 'zulu'
+                  java-version: '17'
+                  cache: 'gradle'
+            - name: APK
+              run: make clean assemble
+            - name: Bundle
+              run: make clean bundle


### PR DESCRIPTION
- Removed the job for cancelling previous workflows, this is not needed as a job or using external action since GitHub provides a way to cancel out of the box. Read more on [Concurrency](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow).
- Removed the trigger for `on push` to main since this felt like a double run which consumes the minutes twice(with the assumption that all code changes will be made via a pull request).
- Update the flow and dependency between jobs, only build can be done after all the other jobs are successful. This will make it easy to track all the failures in a single run. In the previous impl, if `androidTest` and `test` had failures, you first had to fix `test` then wait for the second run to be able to catch failures in the `androidTest`.
   - This also reduces the time the workflow takes to run because the child jobs run in parallel, it only took 3mins while the previous impl took 4mins+, check on compare on [actions](https://github.com/droidconKE/chai/actions)

## Evidence kwa kalatas
1. Cancelled workflow when a new one was triggered
<img width="1098" alt="Screenshot 2024-09-22 at 08 20 33" src="https://github.com/user-attachments/assets/a36bed0e-571f-4926-a2a9-71134737f14d">

2. Re-organization of the jobs
<img width="1098" alt="Screenshot 2024-09-22 at 08 20 53" src="https://github.com/user-attachments/assets/9aa6d52b-2b95-43c6-af60-84f74a799f51">

I am open for discussion 😄 